### PR TITLE
Add support for username in Message

### DIFF
--- a/slackhook.go
+++ b/slackhook.go
@@ -17,6 +17,7 @@ type Message struct {
 	Channel   string `json:"channel,omitempty"`
 	IconURL   string `json:"icon_url,omitempty"`
 	IconEmoji string `json:"icon_emoji,omitempty"`
+	Username  string `json:"username,omitempty"`
 }
 
 // Poster interface is the methods of http.Client required by Client to ease


### PR DESCRIPTION
Adds support for giving your slack message a username, ex. "shakespeare" in the image below.

![screenshot from 2016-01-12 09-04-24](https://cloud.githubusercontent.com/assets/1152361/12270555/82bf9a9a-b90b-11e5-83b7-a0d2f5b34e08.png)
